### PR TITLE
change nightwatch configuration to support multiple environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Set url in end-to-end tests based on environment variable so that it works with any server
 
+## [1.2.2] - 2019-11-05
+- Change `nightwatch` configuration to allow multiple environments
+- Use `browser.launch_url` to specify environment for `nightwatch` end-to-end testing
+
 ## [1.2.1] - 2019-11-04
 - Move unit tests to same directory as end-to-end tests
 - Put unit tests in unit test directory

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ End-to-end testing using `nightwatch`
 $ yarn run e2e
 ```
 
+End-to-end testing with a different environment
+```
+$ yarn run e2e --env accept
+```
+
 Run all tests
 ```
 $ yarn run test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![version](https://img.shields.io/badge/version-1.2.1-green.svg)](https://semver.org)
+[![version](https://img.shields.io/badge/version-1.2.2-green.svg)](https://semver.org)
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
 
 <h1 align="center">

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -9,9 +9,16 @@
 
   "test_settings" : {
     "default" : {
+      "launch_url": "http://localhost:8080",
       "desiredCapabilities": {
         "browserName": "chrome"
       }
+    },
+    "accept" : {
+      "launch_url": "http://accept.host"
+    },
+    "production" : {
+      "launch_url": "http://prod.host"
     }
   }
 }

--- a/src/tests/e2e/test.js
+++ b/src/tests/e2e/test.js
@@ -1,7 +1,7 @@
 module.exports = {
   'example e2e test': function (browser) {
     browser
-      .url('localhost:8080')
+      .url(browser.launch_url)
       .waitForElementVisible('div#app', 1000)
       .assert.containsText('h1', 'App')
       .end()


### PR DESCRIPTION
- Change `nightwatch` configuration to allow multiple environments
- Use `browser.launch_url` to specify environment for `nightwatch` end-to-end testing